### PR TITLE
Update footer: Replace Facebook with LinkedIn and add social URLs

### DIFF
--- a/css/footer.css
+++ b/css/footer.css
@@ -68,6 +68,16 @@ footer .tow .col-lg-6 p {
     margin-bottom: 30px;
 }
 
+footer .tow .col-lg-6 .icons {
+    display: flex;
+    gap: 15px;
+    align-items: center;
+}
+
+footer .tow .col-lg-6 .icons a {
+    display: inline-block;
+}
+
 footer .tow .col-lg-6 .icons i {
     width: 50px;
     height: 50px;
@@ -76,10 +86,8 @@ footer .tow .col-lg-6 .icons i {
     border-radius: 50%;
     background-color: #202020;
     cursor: pointer;
-}
-
-footer .tow .col-lg-6 .icons i:not(:last-child) {
-    margin-right: 15px;
+    color: white;
+    font-size: 24px;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -672,11 +672,19 @@
                         <a href="index.html">gamix<span>.</span></a>
                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nam vero officiis rem consectetur sunt cupiditate eius obcaecati, culpa, aspernatur aperiam id.</p>
                         <div class="icons">
-                            <i class="fab fa-instagram"  data-color="#9147ff"></i>
-                            <i class="fab fa-twitter" data-color="#33ccff"></i>
-                            <i class="fab fa-facebook-f" data-color="#1977f3"></i>
-                            <i class="fab fa-youtube" data-color="#ff0000"></i>
-                        </div>
+                            <a href="https://www.instagram.com/sync_socials/" target="_blank">
+                                <i class="fab fa-instagram" data-color="#9147ff"></i>
+                            </a>
+                            <a href="https://x.com/sync_socials" target="_blank">
+                                <i class="fab fa-twitter" data-color="#33ccff"></i>
+                            </a>
+                            <a href="https://www.linkedin.com/company/syncsocials/" target="_blank">
+                                <i class="fab fa-linkedin" data-color="#0077b5"></i>
+                            </a>
+                            <a href="https://www.youtube.com/@sync_socials/shorts" target="_blank">
+                                <i class="fab fa-youtube" data-color="#ff0000"></i>
+                            </a>
+                        </div>                        
                     </div>
                     <div class="col-lg-2">
                         <h2>Site Menu</h2>


### PR DESCRIPTION
## Description

This PR updates the footer section of the GAMIX website by:

- Removing the Facebook icon from the social media icons.
- Adding the LinkedIn icon with the official SyncSocials LinkedIn URL.
- Adding proper URLs to all social media icons (Instagram, Twitter, LinkedIn, YouTube).
- Wrapping icons in anchor (`<a>`) tags to make them clickable and open in a new tab.
- Fixing the icon layout using CSS flexbox for horizontal alignment with consistent spacing.

This resolves issue #2 
